### PR TITLE
Dash company

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,8 +4,8 @@ class ApplicationController < ActionController::Base
   include Pundit
 
   # Pundit: white-list approach.
-  after_action :verify_authorized, except: :index, unless: :skip_pundit?
-  after_action :verify_policy_scoped, only: :index, unless: :skip_pundit?
+  after_action :verify_authorized, except: [:index, :dashboard], unless: :skip_pundit?
+  after_action :verify_policy_scoped, only: [:index, :dashboard], unless: :skip_pundit?
 
   # Uncomment when you *really understand* Pundit!
   # rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized

--- a/app/controllers/tests_controller.rb
+++ b/app/controllers/tests_controller.rb
@@ -11,10 +11,13 @@ class TestsController < ApplicationController
   end
 
   def create
-    @test = current_user.test.new(test_params)
+    @test = Test.new(test_params)
+    @test.user = current_user
     authorize @test
     if @test.save
-    redirect_to test_path(@test)
+      redirect_to tests_path
+    else
+      render :new
     end
   end
 
@@ -23,12 +26,12 @@ class TestsController < ApplicationController
 
   def update
     @test.update (test_params)
-    redirect_to test_path(@test)
+    redirect_to tests_path
   end
 
   def destroy
-    @test.destroy (test_params)
-    redirect_to test_path
+    @test.destroy
+    redirect_to tests_path
   end
 
   def set_test
@@ -38,6 +41,6 @@ class TestsController < ApplicationController
 
   private
   def test_params
-    params.require(:test).permit(:title, :description)
+    params.require(:test).permit(:title, :description, :seniority, :visa_id)
   end
 end

--- a/app/controllers/tests_controller.rb
+++ b/app/controllers/tests_controller.rb
@@ -1,8 +1,13 @@
 class TestsController < ApplicationController
   before_action :set_test, only: [:edit, :update, :destroy]
 
+
   def index
     @tests = policy_scope(Test).order(created_at: :desc)
+  end
+
+  def dashboard
+    @tests = policy_scope(Test).where(user: current_user).order(created_at: :desc)
   end
 
   def new
@@ -15,7 +20,7 @@ class TestsController < ApplicationController
     @test.user = current_user
     authorize @test
     if @test.save
-      redirect_to tests_path
+      redirect_to dashboard_path
     else
       render :new
     end
@@ -26,12 +31,12 @@ class TestsController < ApplicationController
 
   def update
     @test.update (test_params)
-    redirect_to tests_path
+    redirect_to dashboard_path
   end
 
   def destroy
     @test.destroy
-    redirect_to tests_path
+    redirect_to dashboard_path
   end
 
   def set_test

--- a/app/policies/test_policy.rb
+++ b/app/policies/test_policy.rb
@@ -9,7 +9,15 @@ class TestPolicy < ApplicationPolicy
     true
   end
 
-  def edit?
+  def create?
+    user.role == 3
+  end
+
+  def update?
+    record.user == user
+  end
+
+  def destroy?
     record.user == user
   end
 

--- a/app/policies/test_policy.rb
+++ b/app/policies/test_policy.rb
@@ -1,12 +1,8 @@
 class TestPolicy < ApplicationPolicy
   class Scope < Scope
     def resolve
-      scope.where(user: user)
+      scope.all
     end
-  end
-
-  def index?
-    true
   end
 
   def create?

--- a/app/views/tests/dashboard.html.erb
+++ b/app/views/tests/dashboard.html.erb
@@ -1,0 +1,11 @@
+<h1>All tests your company:</h1>
+
+<td>  <%= link_to "New Test", new_test_path %> </td>
+<tr>
+  <% @tests.each do |test| %>
+  <li>  <%= test.title %>   </li>
+  <li>  <%= test.description %>   </li>
+  <td>  <%= link_to "Edit", edit_test_path(test) %> </td>
+  <td>  <%= link_to "Delete", test_path(test), method: :delete %> </td>
+  <% end %>
+</tr>

--- a/app/views/tests/index.html.erb
+++ b/app/views/tests/index.html.erb
@@ -1,9 +1,12 @@
 <h1>All tests your company:</h1>
 
+<td>  <%= link_to "New Test", new_test_path %> </td>
+
 <tr>
-  <%= @tests.each do |test| %>
+  <% @tests.each do |test| %>
   <li>  <%= test.title %>   </li>
+  <li>  <%= test.description %>   </li>
   <td>  <%= link_to "Edit", edit_test_path(test) %> </td>
-  <td>  <%= link_to "Delete", test_path, method: :delete %> </td>
+  <td>  <%= link_to "Delete", test_path(test), method: :delete %> </td>
   <% end %>
 </tr>

--- a/app/views/tests/index.html.erb
+++ b/app/views/tests/index.html.erb
@@ -1,12 +1,7 @@
 <h1>All tests your company:</h1>
-
-<td>  <%= link_to "New Test", new_test_path %> </td>
-
 <tr>
   <% @tests.each do |test| %>
   <li>  <%= test.title %>   </li>
   <li>  <%= test.description %>   </li>
-  <td>  <%= link_to "Edit", edit_test_path(test) %> </td>
-  <td>  <%= link_to "Delete", test_path(test), method: :delete %> </td>
   <% end %>
 </tr>

--- a/app/views/tests/new.html.erb
+++ b/app/views/tests/new.html.erb
@@ -1,14 +1,14 @@
 <h1>Register your test:</h1>
 
-<%= form_for(@test) do |f| %>
-<%= f.label :title %>
-<%= f.text_field :title %>
+<%= simple_form_for(@test) do |f| %>
 
-<%= f.label :description %>
-<%= f.text_field :description %>
+<%= f.input :title %>
 
-<%= f.label :seniority %>
-<%= f.text_field :seniority %>
+<%= f.input :description %>
+
+<%= f.input :seniority, collection: ["junior", "pleno", "senior"] %>
+
+<%= f.input :visa_id, collection: Visa.all, include_blank: false %>
 
 <%= f.submit %>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,12 +5,7 @@ Rails.application.routes.draw do
 
   resources :reviewers, only: [:index, :show]
 
-  get     'tests',                to: 'tests#index'
-  get     'tests/new',            to: 'tests#new',            as: 'test'
-  post    'tests',                to: 'tests#creat'
-  get     'tests/:id/edit',       to: 'tests#edit',           as: 'edit_test'
-  patch   'tests/:id',            to: 'tests#update'
-  delete  'tests/:id',            to: 'tests#destroy'
+  resources :tests, except: [:show]
 
   get     '/visas/',              to: "visas#index"
   get     '/visas/:id',           to: "visas#show",           as: "visa"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,8 @@ Rails.application.routes.draw do
 
   resources :tests, except: [:show]
 
+  get '/dashboard/', to: "tests#dashboard"
+
   get     '/visas/',              to: "visas#index"
   get     '/visas/:id',           to: "visas#show",           as: "visa"
 


### PR DESCRIPTION
Alterações feitas no test controller, police test, routes de test e dashboard. 
Os testes da empresa são todos apresentados na dashboard, onde podem ser criados, editados e deletados, utilizando a autorização do pelo role 3.
Foram criados também os campos para inclusão de senioridades e visa, que estava atrelado ao teste. 
Na index serão listados todos os testes, de todas as empresas, sem necessidade de autorização prévia para visualização (isso pode ser modificado posteriormente).
Foi removida a hash que era mostrada no fim da index view (removido o "=" que estava dentro do loop de iteração dos testes).
Todos os campos foram testados previamente.